### PR TITLE
Add support to {Python,Sublime Text} 3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Francesco Banconi <francesco.banconi@canonical.com>
+Marco Trevisan <marco.trevisan@canonical.com>

--- a/README.rst
+++ b/README.rst
@@ -2,14 +2,14 @@
 Ubuntu Paste
 ============
 
-This Sublime Text 2 plugin can be used to paste code snippets on
+This Sublime Text 2 and 3 plugin can be used to paste code snippets on
 http://pastebin.ubuntu.com/
 
 Installation
 ============
 
 Branch this project into Sublime Text Packages directory.
-On Linux: ``~/.config/sublime-text-2/Packages/``
+On Linux: ``~/.config/sublime-text-{2,3}/Packages/``
 On MacOs: ``~/Library/Application Support/Sublime Text 2/Packages/``
 
 E.g.::

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Ubuntu Paste
 ============
 
 This Sublime Text 2 and 3 plugin can be used to paste code snippets on
-http://pastebin.ubuntu.com/
+https://pastebin.ubuntu.com/
 
 Installation
 ============

--- a/UbuntuPaste.sublime-settings
+++ b/UbuntuPaste.sublime-settings
@@ -37,7 +37,8 @@
         "restructuredtext": "rst",
         "shell-unix-generic": "bash",
         "sql": "sql",
-        "xml": "xml"
+        "xml": "xml",
+        "vala": "csharp"
     },
 
     // The pastebin URL.

--- a/UbuntuPaste.sublime-settings
+++ b/UbuntuPaste.sublime-settings
@@ -42,5 +42,5 @@
     },
 
     // The pastebin URL.
-    "url": "http://pastebin.ubuntu.com/"
+    "url": "https://pastebin.ubuntu.com/"
 }

--- a/ubuntupaste.py
+++ b/ubuntupaste.py
@@ -3,10 +3,10 @@
 
 import itertools
 import os
+import sys
 import pwd
 import threading
-import urllib
-import urllib2
+import urllib.request, urllib.parse, urllib.error
 import webbrowser
 
 import sublime
@@ -34,7 +34,7 @@ class UserInterface(object):
 
     def progress(self, url):
         """Show pasting progress."""
-        dots = '.' * (self.count.next() % 4)
+        dots = '.' * (next(self.count) % 4)
         self.status('Pasting to', url, '[', dots.ljust(3), ']')
 
     def error(self, *contents):
@@ -117,13 +117,17 @@ class Paster(threading.Thread):
 
     def run(self):
         try:
-            request = urllib2.Request(
-                self.url, urllib.urlencode(self.data),
-                headers={'User-Agent': 'SublimeText2'})
-            response = urllib2.urlopen(request, timeout=5)
-        except urllib2.HTTPError as err:
+            data = bytearray(
+                urllib.parse.urlencode(self.data),
+                encoding=sys.getfilesystemencoding()
+            )
+            request = urllib.request.Request(
+                self.url, data, headers={'User-Agent': 'SublimeText2'}
+            )
+            response = urllib.request.urlopen(request, timeout=5)
+        except urllib.error.HTTPError as err:
             self.error = 'HTTP error {0}.'.format(err.code)
-        except urllib2.URLError as err:
+        except urllib.error.URLError as err:
             self.error = 'URL error {0}.'.format(err.reason)
         else:
             self.result = response.url

--- a/ubuntupaste.py
+++ b/ubuntupaste.py
@@ -148,7 +148,7 @@ class Paster(threading.Thread):
 
 
 class UbuntupasteCommand(sublime_plugin.TextCommand):
-    """Paste code snippets on http://pastebin.ubuntu.com/."""
+    """Paste code snippets on https://pastebin.ubuntu.com/."""
 
     def __init__(self, *args, **kwargs):
         self.ui = None

--- a/ubuntupaste.py
+++ b/ubuntupaste.py
@@ -120,12 +120,11 @@ class Paster(threading.Thread):
             import urllib, urllib2
             self.__urlencode = urllib.urlencode
             self.__urlrequest = urllib2
-            self.__urlerror = urllib2
         except ImportError:
-            import urllib.request, urllib.parse, urllib.error
-            self.__urlencode = urllib.parse.urlencode
+            import urllib.request
+            from urllib.parse import urlencode
+            self.__urlencode = urlencode
             self.__urlrequest = urllib.request
-            self.__urlerror = urllib.error
 
         threading.Thread.__init__(self)
 
@@ -139,10 +138,8 @@ class Paster(threading.Thread):
                 self.url, data, headers=self.HEADERS
             )
             response = self.__urlrequest.urlopen(request, timeout=self.TIMEOUT)
-        except self.__urlerror.HTTPError as err:
-            self.error = 'HTTP error {0}.'.format(err.code)
-        except self.__urlerror.URLError as err:
-            self.error = 'URL error {0}.'.format(err.reason)
+        except Exception as err:
+            self.error = 'Plugin error: {0}.'.format(err)
         else:
             self.result = response.url
 

--- a/ubuntupaste.py
+++ b/ubuntupaste.py
@@ -115,10 +115,10 @@ class Paster(threading.Thread):
         self.data = kwargs
         self.error = None
         self.result = None
-        self.__urlopen = getattr(self, "_{0}__urlopen{1}".format(self.__class__.__name__, sys.version_info[0]))
+        self.__do_req = getattr(self, "_{0}__do_req{1}".format(self.__class__.__name__, sys.version_info[0]))
         threading.Thread.__init__(self)
 
-    def __urlopen2(self):
+    def __do_req2(self):
         import urllib, urllib2
 
         try:
@@ -133,7 +133,7 @@ class Paster(threading.Thread):
         else:
             self.result = response.url
 
-    def __urlopen3(self):
+    def __do_req3(self):
         import urllib.request, urllib.parse, urllib.error
 
         try:
@@ -153,7 +153,7 @@ class Paster(threading.Thread):
             self.result = response.url
 
     def run(self):
-        self.__urlopen()
+        self.__do_req()
 
 
 class UbuntupasteCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
Made the Paster to use dynamically the proper method for posting data in Python 2 or 3 (the code change is so small that having different branches is not needed).

Wrapping urllib inside another class would have been probably too much for this.
In [this branch](https://github.com/3v1n0/UbuntuPaste/blob/dynamic-func/ubuntupaste.py#L118), there's another way for achieving the same result, just let me know the one you prefer...
